### PR TITLE
Add approval mode feature for scheduled cleanups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,14 @@ _pkginfo.txt
 ## Local data
 *.db
 *.sqlite
+Building_SentinAI_Medium_Article.md
+images/ai-reasoning.png
+images/dashboard-overview.png
+images/monitoring-stats.png
+test-duplicates/unique1.txt
+test-duplicates/unique2.txt
+test-duplicates/folder1/file1.txt
+test-duplicates/folder1/group2.txt
+test-duplicates/folder2/file1_copy.txt
+test-duplicates/folder2/group2_copy.txt
+test-duplicates/folder3/another_copy.txt

--- a/src/SentinAI.Web/Components/Layout/NavMenu.razor
+++ b/src/SentinAI.Web/Components/Layout/NavMenu.razor
@@ -29,6 +29,12 @@
             </NavLink>
         </div>
 
+        <div class="nav-item px-3">
+            <NavLink class="nav-link" href="cleanup-reports">
+                <span class="nav-icon">📋</span> Pending Reviews
+            </NavLink>
+        </div>
+
         @* Divider *@
         <div class="nav-section-divider px-3 mt-3 mb-2">
             <small class="text-uppercase text-muted">Advanced</small>

--- a/src/SentinAI.Web/Components/Pages/CleanupReports.razor
+++ b/src/SentinAI.Web/Components/Pages/CleanupReports.razor
@@ -1,0 +1,353 @@
+@page "/cleanup-reports"
+@using System.Net.Http.Json
+@inject IHttpClientFactory HttpClientFactory
+@inject NavigationManager Navigation
+@rendermode InteractiveServer
+
+<PageTitle>Cleanup Reports - SentinAI</PageTitle>
+
+<div class="reports-container">
+    <div class="text-center mb-4">
+        <h1 class="display-6">📋 Cleanup Reports</h1>
+        <p class="text-muted">Review AI findings and approve or reject cleanup recommendations</p>
+    </div>
+
+    @* Pending Items Alert *@
+    @if (pendingItems != null && pendingItems.Any())
+    {
+        <div class="row justify-content-center mb-4">
+            <div class="col-lg-10">
+                <div class="alert alert-warning d-flex align-items-center justify-content-between" role="alert">
+                    <div>
+                        <strong>📋 @pendingItems.Count items pending review</strong>
+                        <span class="text-muted ms-2">(@FormatBytes(pendingItems.Sum(p => p.SizeBytes)) potential space)</span>
+                    </div>
+                    <div>
+                        <button class="btn btn-success btn-sm me-2" @onclick="ApproveAll" disabled="@isProcessing">
+                            ✅ Approve All
+                        </button>
+                        <button class="btn btn-outline-secondary btn-sm" @onclick="RejectAll" disabled="@isProcessing">
+                            ❌ Keep All
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </div>
+    }
+
+    @* Pending Items List *@
+    <div class="row justify-content-center mb-4">
+        <div class="col-lg-10">
+            <div class="card border-0 shadow-sm">
+                <div class="card-header bg-white border-0 pt-4">
+                    <h5 class="mb-0">
+                        <span class="me-2">⏳</span>
+                        Pending Review
+                    </h5>
+                </div>
+                <div class="card-body">
+                    @if (isLoading)
+                    {
+                        <div class="text-center py-4">
+                            <div class="spinner-border text-primary" role="status"></div>
+                            <p class="mt-2 text-muted">Loading pending items...</p>
+                        </div>
+                    }
+                    else if (pendingItems == null || !pendingItems.Any())
+                    {
+                        <div class="text-center py-5">
+                            <span class="display-4">✨</span>
+                            <h5 class="mt-3 text-muted">No pending reviews</h5>
+                            <p class="text-muted small">All caught up! Check back after your scheduled cleanups run.</p>
+                            <a href="/scheduler" class="btn btn-primary mt-2">
+                                ⏰ Manage Schedules
+                            </a>
+                        </div>
+                    }
+                    else
+                    {
+                        <div class="table-responsive">
+                            <table class="table table-hover align-middle">
+                                <thead class="table-light">
+                                    <tr>
+                                        <th>File</th>
+                                        <th>Size</th>
+                                        <th>Category</th>
+                                        <th>AI Confidence</th>
+                                        <th>AI Reasoning</th>
+                                        <th class="text-end">Actions</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    @foreach (var item in pendingItems)
+                                    {
+                                        <tr>
+                                            <td>
+                                                <div class="d-flex align-items-center">
+                                                    <span class="me-2">📄</span>
+                                                    <div>
+                                                        <div class="fw-semibold text-truncate" style="max-width: 250px;" title="@item.FilePath">
+                                                            @item.FileName
+                                                        </div>
+                                                        <small class="text-muted text-truncate d-block" style="max-width: 250px;">
+                                                            @GetDirectoryPath(item.FilePath)
+                                                        </small>
+                                                    </div>
+                                                </div>
+                                            </td>
+                                            <td>@FormatBytes(item.SizeBytes)</td>
+                                            <td>
+                                                <span class="badge bg-secondary">@item.Category</span>
+                                            </td>
+                                            <td>
+                                                <div class="d-flex align-items-center">
+                                                    <div class="progress flex-grow-1 me-2" style="width: 60px; height: 8px;">
+                                                        <div class="progress-bar @GetConfidenceColor(item.AiConfidence)" 
+                                                             style="width: @(item.AiConfidence * 100)%"></div>
+                                                    </div>
+                                                    <span class="small">@((item.AiConfidence * 100).ToString("F0"))%</span>
+                                                </div>
+                                            </td>
+                                            <td>
+                                                <small class="text-muted" title="@item.AiReasoning">
+                                                    @TruncateText(item.AiReasoning, 50)
+                                                </small>
+                                            </td>
+                                            <td class="text-end">
+                                                <button class="btn btn-success btn-sm me-1" 
+                                                        @onclick="() => ApproveItem(item.Id)"
+                                                        disabled="@isProcessing"
+                                                        title="Delete this file">
+                                                    ✅
+                                                </button>
+                                                <button class="btn btn-outline-secondary btn-sm" 
+                                                        @onclick="() => RejectItem(item.Id)"
+                                                        disabled="@isProcessing"
+                                                        title="Keep this file">
+                                                    ❌
+                                                </button>
+                                            </td>
+                                        </tr>
+                                    }
+                                </tbody>
+                            </table>
+                        </div>
+                    }
+                </div>
+            </div>
+        </div>
+    </div>
+
+    @* Recent Reports Section *@
+    @if (recentHistory != null && recentHistory.Any())
+    {
+        <div class="row justify-content-center">
+            <div class="col-lg-10">
+                <div class="card border-0 shadow-sm">
+                    <div class="card-header bg-white border-0 pt-4">
+                        <h5 class="mb-0">
+                            <span class="me-2">📊</span>
+                            Recent Cleanup Reports
+                        </h5>
+                    </div>
+                    <div class="card-body">
+                        <div class="list-group list-group-flush">
+                            @foreach (var entry in recentHistory.Take(10))
+                            {
+                                <div class="list-group-item px-0 py-3 d-flex justify-content-between align-items-center">
+                                    <div>
+                                        <span class="me-2">@(entry.Success ? "✅" : "❌")</span>
+                                        <span class="fw-semibold">@entry.TaskName</span>
+                                        <small class="text-muted ms-2">
+                                            @entry.ExecutedAt.ToLocalTime().ToString("MMM d, h:mm tt")
+                                        </small>
+                                    </div>
+                                    <div class="d-flex align-items-center gap-2">
+                                        @if (entry.BytesFreed > 0)
+                                        {
+                                            <span class="badge bg-success-subtle text-success">
+                                                @FormatBytes(entry.BytesFreed) freed
+                                            </span>
+                                        }
+                                        @if (entry.FilesDeleted > 0)
+                                        {
+                                            <span class="badge bg-info-subtle text-info">
+                                                @entry.FilesDeleted files
+                                            </span>
+                                        }
+                                    </div>
+                                </div>
+                            }
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    }
+</div>
+
+<style>
+    .reports-container {
+        max-width: 1200px;
+        margin: 0 auto;
+        padding: 2rem 1rem;
+    }
+
+    .bg-success-subtle {
+        background-color: rgba(25, 135, 84, 0.1);
+    }
+    
+    .bg-info-subtle {
+        background-color: rgba(13, 202, 240, 0.1);
+    }
+</style>
+
+@code {
+    private List<PendingItemDto>? pendingItems;
+    private List<ExecutionHistoryDto>? recentHistory;
+    private bool isLoading = true;
+    private bool isProcessing;
+
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadData();
+    }
+
+    private async Task LoadData()
+    {
+        isLoading = true;
+        try
+        {
+            var httpClient = HttpClientFactory.CreateClient();
+            httpClient.BaseAddress ??= new Uri(Navigation.BaseUri);
+            
+            pendingItems = await httpClient.GetFromJsonAsync<List<PendingItemDto>>("api/scheduler/pending");
+            recentHistory = await httpClient.GetFromJsonAsync<List<ExecutionHistoryDto>>("api/scheduler/history");
+        }
+        catch
+        {
+            pendingItems = new();
+            recentHistory = new();
+        }
+        finally
+        {
+            isLoading = false;
+        }
+    }
+
+    private async Task ApproveItem(string itemId)
+    {
+        isProcessing = true;
+        try
+        {
+            var httpClient = HttpClientFactory.CreateClient();
+            httpClient.BaseAddress ??= new Uri(Navigation.BaseUri);
+            await httpClient.PostAsync($"api/scheduler/pending/{itemId}/approve", null);
+            await LoadData();
+        }
+        finally
+        {
+            isProcessing = false;
+        }
+    }
+
+    private async Task RejectItem(string itemId)
+    {
+        isProcessing = true;
+        try
+        {
+            var httpClient = HttpClientFactory.CreateClient();
+            httpClient.BaseAddress ??= new Uri(Navigation.BaseUri);
+            await httpClient.PostAsync($"api/scheduler/pending/{itemId}/reject", null);
+            await LoadData();
+        }
+        finally
+        {
+            isProcessing = false;
+        }
+    }
+
+    private async Task ApproveAll()
+    {
+        isProcessing = true;
+        try
+        {
+            var httpClient = HttpClientFactory.CreateClient();
+            httpClient.BaseAddress ??= new Uri(Navigation.BaseUri);
+            await httpClient.PostAsync("api/scheduler/pending/approve-all?taskId=all", null);
+            await LoadData();
+        }
+        finally
+        {
+            isProcessing = false;
+        }
+    }
+
+    private async Task RejectAll()
+    {
+        isProcessing = true;
+        try
+        {
+            var httpClient = HttpClientFactory.CreateClient();
+            httpClient.BaseAddress ??= new Uri(Navigation.BaseUri);
+            await httpClient.PostAsync("api/scheduler/pending/reject-all?taskId=all", null);
+            await LoadData();
+        }
+        finally
+        {
+            isProcessing = false;
+        }
+    }
+
+    private static string FormatBytes(long bytes)
+    {
+        if (bytes < 1024) return $"{bytes} B";
+        if (bytes < 1024 * 1024) return $"{bytes / 1024.0:F1} KB";
+        if (bytes < 1024 * 1024 * 1024) return $"{bytes / (1024.0 * 1024):F1} MB";
+        return $"{bytes / (1024.0 * 1024 * 1024):F2} GB";
+    }
+
+    private static string GetDirectoryPath(string filePath)
+    {
+        try { return Path.GetDirectoryName(filePath) ?? ""; }
+        catch { return ""; }
+    }
+
+    private static string TruncateText(string text, int maxLength)
+    {
+        if (string.IsNullOrEmpty(text)) return "";
+        return text.Length <= maxLength ? text : text.Substring(0, maxLength) + "...";
+    }
+
+    private static string GetConfidenceColor(double confidence)
+    {
+        return confidence switch
+        {
+            >= 0.9 => "bg-success",
+            >= 0.7 => "bg-warning",
+            _ => "bg-danger"
+        };
+    }
+
+    // DTOs
+    private class PendingItemDto
+    {
+        public string Id { get; set; } = "";
+        public string FilePath { get; set; } = "";
+        public string FileName { get; set; } = "";
+        public long SizeBytes { get; set; }
+        public string Category { get; set; } = "";
+        public double AiConfidence { get; set; }
+        public string AiReasoning { get; set; } = "";
+        public bool AiRecommendsDeletion { get; set; }
+    }
+
+    private record ExecutionHistoryDto(
+        string TaskId,
+        string TaskName,
+        DateTimeOffset ExecutedAt,
+        bool Success,
+        int FilesDeleted,
+        long BytesFreed,
+        string? ErrorMessage);
+}

--- a/src/SentinAI.Web/Components/Pages/Scheduler.razor
+++ b/src/SentinAI.Web/Components/Pages/Scheduler.razor
@@ -27,6 +27,25 @@
                             <p class="card-text text-muted small">
                                 Clean temp files and caches every day at 2 AM
                             </p>
+                            
+                            @* AI Decision Mode Toggle *@
+                            <div class="approval-mode-toggle mb-3">
+                                <div class="btn-group btn-group-sm w-100" role="group">
+                                    <input type="radio" class="btn-check" name="daily-mode" id="daily-ai" 
+                                           checked="@(GetApprovalMode("daily") == "ai")"
+                                           @onchange='() => SetApprovalMode("daily", "ai")'>
+                                    <label class="btn btn-outline-primary" for="daily-ai" title="AI will automatically delete files it deems safe">
+                                        🤖 AI Decides
+                                    </label>
+                                    <input type="radio" class="btn-check" name="daily-mode" id="daily-review"
+                                           checked="@(GetApprovalMode("daily") == "review")"
+                                           @onchange='() => SetApprovalMode("daily", "review")'>
+                                    <label class="btn btn-outline-primary" for="daily-review" title="Review AI findings before deletion">
+                                        👁️ Review First
+                                    </label>
+                                </div>
+                            </div>
+                            
                             <div class="schedule-status mt-3">
                                 @if (HasSchedule("daily"))
                                 {
@@ -57,6 +76,25 @@
                             <p class="card-text text-muted small">
                                 Thorough cleanup every Sunday at 3 AM
                             </p>
+                            
+                            @* AI Decision Mode Toggle *@
+                            <div class="approval-mode-toggle mb-3">
+                                <div class="btn-group btn-group-sm w-100" role="group">
+                                    <input type="radio" class="btn-check" name="weekly-mode" id="weekly-ai" 
+                                           checked="@(GetApprovalMode("weekly") == "ai")"
+                                           @onchange='() => SetApprovalMode("weekly", "ai")'>
+                                    <label class="btn btn-outline-primary" for="weekly-ai" title="AI will automatically delete files it deems safe">
+                                        🤖 AI Decides
+                                    </label>
+                                    <input type="radio" class="btn-check" name="weekly-mode" id="weekly-review"
+                                           checked="@(GetApprovalMode("weekly") == "review")"
+                                           @onchange='() => SetApprovalMode("weekly", "review")'>
+                                    <label class="btn btn-outline-primary" for="weekly-review" title="Review AI findings before deletion">
+                                        👁️ Review First
+                                    </label>
+                                </div>
+                            </div>
+                            
                             <div class="schedule-status mt-3">
                                 @if (HasSchedule("weekly"))
                                 {
@@ -87,6 +125,25 @@
                             <p class="card-text text-muted small">
                                 Clean old downloads on the 1st of each month
                             </p>
+                            
+                            @* AI Decision Mode Toggle *@
+                            <div class="approval-mode-toggle mb-3">
+                                <div class="btn-group btn-group-sm w-100" role="group">
+                                    <input type="radio" class="btn-check" name="monthly-mode" id="monthly-ai" 
+                                           checked="@(GetApprovalMode("monthly") == "ai")"
+                                           @onchange='() => SetApprovalMode("monthly", "ai")'>
+                                    <label class="btn btn-outline-primary" for="monthly-ai" title="AI will automatically delete files it deems safe">
+                                        🤖 AI Decides
+                                    </label>
+                                    <input type="radio" class="btn-check" name="monthly-mode" id="monthly-review"
+                                           checked="@(GetApprovalMode("monthly") == "review")"
+                                           @onchange='() => SetApprovalMode("monthly", "review")'>
+                                    <label class="btn btn-outline-primary" for="monthly-review" title="Review AI findings before deletion">
+                                        👁️ Review First
+                                    </label>
+                                </div>
+                            </div>
+                            
                             <div class="schedule-status mt-3">
                                 @if (HasSchedule("monthly"))
                                 {
@@ -177,6 +234,35 @@
                                     </select>
                                 </div>
                             }
+                            
+                            @* AI Decision Mode *@
+                            <div class="col-12">
+                                <label class="form-label fw-semibold">How should AI handle cleanup?</label>
+                                <div class="row g-2">
+                                    <div class="col-md-6">
+                                        <div class="form-check card p-3 @(newTask.ApprovalMode == "ai" ? "border-primary" : "")">
+                                            <input class="form-check-input" type="radio" name="approval-mode" id="custom-ai-mode"
+                                                   checked="@(newTask.ApprovalMode == "ai")"
+                                                   @onchange='() => newTask.ApprovalMode = "ai"'>
+                                            <label class="form-check-label" for="custom-ai-mode">
+                                                <span class="fw-semibold">🤖 Let AI Decide</span>
+                                                <br><small class="text-muted">AI automatically deletes files it confidently identifies as safe to remove</small>
+                                            </label>
+                                        </div>
+                                    </div>
+                                    <div class="col-md-6">
+                                        <div class="form-check card p-3 @(newTask.ApprovalMode == "review" ? "border-primary" : "")">
+                                            <input class="form-check-input" type="radio" name="approval-mode" id="custom-review-mode"
+                                                   checked="@(newTask.ApprovalMode == "review")"
+                                                   @onchange='() => newTask.ApprovalMode = "review"'>
+                                            <label class="form-check-label" for="custom-review-mode">
+                                                <span class="fw-semibold">👁️ Review Findings First</span>
+                                                <br><small class="text-muted">AI analyzes files and presents a report for your approval before any deletion</small>
+                                            </label>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
                         </div>
                         
                         <div class="mt-4">
@@ -232,14 +318,14 @@
                             {
                                 <div class="list-group-item px-0 py-3 d-flex justify-content-between align-items-center">
                                     <div class="d-flex align-items-center">
-                                        <span class="task-type-icon me-3">@GetTaskTypeEmoji(task.TaskType)</span>
+                                        <span class="task-type-icon me-3">@GetTaskTypeEmojiFromInt(task.TaskType)</span>
                                         <div>
                                             <div class="fw-semibold">@task.Name</div>
                                             <small class="text-muted">
                                                 @GetFriendlySchedule(task.CronExpression)
-                                                @if (task.NextRunTime.HasValue)
+                                                @if (task.NextRunAt.HasValue)
                                                 {
-                                                    <span class="ms-2">• Next: @task.NextRunTime.Value.ToLocalTime().ToString("MMM d, h:mm tt")</span>
+                                                    <span class="ms-2">• Next: @task.NextRunAt.Value.ToLocalTime().ToString("MMM d, h:mm tt")</span>
                                                 }
                                             </small>
                                         </div>
@@ -378,6 +464,14 @@
     .dropdown-toggle::after {
         display: none;
     }
+    
+    .approval-mode-toggle .btn-group {
+        font-size: 0.75rem;
+    }
+    
+    .approval-mode-toggle .btn {
+        padding: 0.25rem 0.5rem;
+    }
 </style>
 
 @code {
@@ -394,16 +488,32 @@
     private bool isLoadingTasks = true;
     
     private List<ExecutionHistoryDto>? executionHistory;
+    
+    // Approval mode settings for quick schedules (stored locally until task is enabled)
+    private Dictionary<string, string> approvalModes = new()
+    {
+        { "daily", "ai" },
+        { "weekly", "ai" },
+        { "monthly", "review" } // Default monthly to review since it involves user downloads
+    };
 
-    // Quick schedule identifiers
-    private const string DailyScheduleName = "[Auto] Daily Cleanup";
-    private const string WeeklyScheduleName = "[Auto] Weekly Deep Clean";
-    private const string MonthlyScheduleName = "[Auto] Monthly Downloads Cleanup";
+    // Quick schedule identifiers - match backend default task IDs
+    private const string DailyScheduleId = "daily-temp-cleanup";
+    private const string WeeklyScheduleId = "weekly-duplicate-scan";
+    private const string MonthlyScheduleId = "monthly-downloads-cleanup";
 
     protected override async Task OnInitializedAsync()
     {
         await LoadTasks();
         await LoadHistory();
+    }
+    
+    private string GetApprovalMode(string type) => approvalModes.GetValueOrDefault(type, "ai");
+    
+    private void SetApprovalMode(string type, string mode)
+    {
+        approvalModes[type] = mode;
+        StateHasChanged();
     }
 
     private bool HasSchedule(string type)
@@ -411,43 +521,34 @@
         if (tasks == null) return false;
         return type switch
         {
-            "daily" => tasks.Any(t => t.Name == DailyScheduleName),
-            "weekly" => tasks.Any(t => t.Name == WeeklyScheduleName),
-            "monthly" => tasks.Any(t => t.Name == MonthlyScheduleName),
+            "daily" => tasks.Any(t => t.Id == DailyScheduleId && t.IsEnabled),
+            "weekly" => tasks.Any(t => t.Id == WeeklyScheduleId && t.IsEnabled),
+            "monthly" => tasks.Any(t => t.Id == MonthlyScheduleId && t.IsEnabled),
             _ => false
         };
     }
 
     private async Task AddQuickSchedule(string type)
     {
-        var (name, cron, taskType, description) = type switch
+        var taskId = type switch
         {
-            "daily" => (DailyScheduleName, "0 2 * * *", "TempCleanup", "Cleans temp files and caches daily at 2 AM"),
-            "weekly" => (WeeklyScheduleName, "0 3 * * 0", "BrowserCache", "Deep cleans browser cache every Sunday at 3 AM"),
-            "monthly" => (MonthlyScheduleName, "0 4 1 * *", "DownloadsCleanup", "Cleans old downloads on the 1st of each month"),
-            _ => ("", "", "", "")
+            "daily" => DailyScheduleId,
+            "weekly" => WeeklyScheduleId,
+            "monthly" => MonthlyScheduleId,
+            _ => ""
         };
 
-        if (string.IsNullOrEmpty(name)) return;
+        if (string.IsNullOrEmpty(taskId)) return;
 
         try
         {
             var httpClient = HttpClientFactory.CreateClient();
             httpClient.BaseAddress ??= new Uri(Navigation.BaseUri);
             
-            var request = new
-            {
-                Name = name,
-                Description = description,
-                CronExpression = cron,
-                TaskType = taskType,
-                TargetPath = "",
-                FileAgeDays = 30,
-                IsEnabled = true
-            };
-            
-            await httpClient.PostAsJsonAsync("api/scheduler/tasks", request);
+            // Enable the existing default task
+            await httpClient.PostAsync($"api/scheduler/tasks/{taskId}/enable", null);
             await LoadTasks();
+            StateHasChanged();
         }
         catch
         {
@@ -457,20 +558,29 @@
 
     private async Task RemoveQuickSchedule(string type)
     {
-        if (tasks == null) return;
-        
-        var name = type switch
+        var taskId = type switch
         {
-            "daily" => DailyScheduleName,
-            "weekly" => WeeklyScheduleName,
-            "monthly" => MonthlyScheduleName,
+            "daily" => DailyScheduleId,
+            "weekly" => WeeklyScheduleId,
+            "monthly" => MonthlyScheduleId,
             _ => ""
         };
 
-        var task = tasks.FirstOrDefault(t => t.Name == name);
-        if (task != null)
+        if (string.IsNullOrEmpty(taskId)) return;
+
+        try
         {
-            await DeleteTask(task.Id);
+            var httpClient = HttpClientFactory.CreateClient();
+            httpClient.BaseAddress ??= new Uri(Navigation.BaseUri);
+            
+            // Disable the task instead of deleting it
+            await httpClient.PostAsync($"api/scheduler/tasks/{taskId}/disable", null);
+            await LoadTasks();
+            StateHasChanged();
+        }
+        catch
+        {
+            // Silently fail
         }
     }
 
@@ -504,6 +614,16 @@
         "RecycleBin" => "🗄️",
         "DuplicateScan" => "📂",
         "CustomFolder" => "📁",
+        _ => "📋"
+    };
+
+    // Maps ScheduledTaskType enum values to emojis
+    // 0 = Cleanup, 1 = DuplicateScan, 2 = FullSystemScan
+    private string GetTaskTypeEmojiFromInt(int taskType) => taskType switch
+    {
+        0 => "🗑️", // Cleanup
+        1 => "📂", // DuplicateScan
+        2 => "🔍", // FullSystemScan
         _ => "📋"
     };
 
@@ -684,19 +804,22 @@
         public string TaskType { get; set; } = "TempCleanup";
         public string TargetPath { get; set; } = "";
         public int FileAgeDays { get; set; } = 30;
+        public string ApprovalMode { get; set; } = "ai"; // "ai" or "review"
     }
 
-    private record ScheduledTaskDto(
-        string Id,
-        string Name,
-        string? Description,
-        string CronExpression,
-        string TaskType,
-        string? TargetPath,
-        bool IsEnabled,
-        DateTimeOffset? NextRunTime,
-        DateTimeOffset? LastRunTime,
-        bool? LastRunSuccess);
+    // DTO matching the backend ScheduledTask JSON serialization
+    private class ScheduledTaskDto
+    {
+        public string Id { get; set; } = "";
+        public string Name { get; set; } = "";
+        public string? Description { get; set; }
+        public string CronExpression { get; set; } = "";
+        public int TaskType { get; set; }
+        public bool IsEnabled { get; set; }
+        public DateTime? NextRunAt { get; set; }
+        public DateTime? LastRunAt { get; set; }
+        public int LastStatus { get; set; }
+    }
 
     private record ExecutionHistoryDto(
         string TaskId,


### PR DESCRIPTION
- Add CleanupApprovalMode enum (LetAIDecide, ReviewFirst) to ScheduledCleanupService
- Add PendingCleanupItem and CleanupReport models for tracking cleanup reviews
- Update Scheduler.razor UI with approval mode toggles for each schedule type
- Add API endpoints for pending reviews: get, approve, reject items
- Create CleanupReports.razor page for viewing and managing pending cleanup reviews
- Add navigation link to Pending Reviews in NavMenu
- When ReviewFirst mode is selected, files are queued for user approval instead of auto-deleted