### PR TITLE
Upgrade to Phi-4 Mini ONNX model

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -6,7 +6,7 @@ This document describes the architecture and design decisions of SentinAI.
 
 SentinAI uses a **hybrid AI + heuristics architecture** where:
 1. **Heuristics** provide fast, rule-based context
-2. **AI (Phi-3 Mini)** makes the final safety decision
+2. **AI (Phi-4 Mini)** makes the final safety decision
 
 This approach combines the speed of rules with the intelligence of AI.
 
@@ -78,7 +78,7 @@ This approach combines the speed of rules with the intelligence of AI.
                          ▼
 ┌──────────────────────────────────────────────────────────┐
 │              STEP 2: AI Decision                         │
-│                  (5-15s on CPU)                          │
+│                  (3-10s on CPU)                          │
 │  ┌────────────────────────────────────────────────────┐  │
 │  │ • Receives heuristic context                       │  │
 │  │ • Analyzes path semantics                          │  │
@@ -97,11 +97,10 @@ This approach combines the speed of rules with the intelligence of AI.
 └──────────────────────────────────────────────────────────┘
 ```
 
-## AI Model: Phi-3 Mini
+## AI Model: Phi-4 Mini
 
-### Why Phi-3?
-- **Small size:** ~2.5GB quantized (vs 8GB+ for larger models)
-- **Fast inference:** Works on CPU and GPU
+### Why Phi-4?\n- **Compact size:** ~2.5GB quantized - runs on consumer hardware\n- **Better reasoning:** Significantly improved logic and math capabilities", "oldString": "### Why Phi-4?\n- **Same size:** ~2.5GB quantized (same as Phi-3 Mini)\n- **Better reasoning:** Significantly improved logic and math capabilities
+- **Fast inference:** Works on CPU and GPU (DirectML)
 - **MIT License:** Commercial use allowed
 - **Microsoft optimized:** ONNX Runtime GenAI support
 
@@ -110,7 +109,7 @@ This approach combines the speed of rules with the intelligence of AI.
 | Variant | Provider | Package | Use Case |
 |---------|----------|---------|----------|
 | CPU INT4 | CPU | `Microsoft.ML.OnnxRuntimeGenAI` | Universal compatibility |
-| DirectML INT4 | GPU | `Microsoft.ML.OnnxRuntimeGenAI.DirectML` | Fast inference |
+| GPU INT4 | GPU | `Microsoft.ML.OnnxRuntimeGenAI.DirectML` | Fast inference |
 
 ### Configuration
 
@@ -118,7 +117,7 @@ This approach combines the speed of rules with the intelligence of AI.
 {
   "Brain": {
     "ExecutionProvider": "CPU",      // or "DirectML"
-    "MaxSequenceLength": 2048,       // Total context window
+    "MaxSequenceLength": 4096,       // Total context window
     "MaxOutputTokens": 150,          // Response length limit
     "InferenceTimeoutSeconds": 60,
     "Temperature": 0.1               // Low = deterministic
@@ -193,9 +192,9 @@ string[] AlwaysExclude = {
 ### Inference Times (Typical)
 
 | Hardware | Time per Folder |
-|----------|-----------------|
-| Modern CPU (i7/Ryzen 7) | 5-10 seconds |
-| GPU (RTX 3060+) | 1-3 seconds |
+|----------|----------------|
+| Modern CPU (i7/Ryzen 7) | 3-8 seconds |
+| GPU (RTX 3060+) | 1-2 seconds |
 | NPU (Copilot+ PC) | <1 second |
 
 ### Memory Usage

--- a/LICENSE
+++ b/LICENSE
@@ -29,8 +29,8 @@ This software uses the following third-party libraries:
 1. Microsoft ONNX Runtime GenAI (MIT License)
    https://github.com/microsoft/onnxruntime-genai
 
-2. Phi-3 Model (MIT License)
-   https://huggingface.co/microsoft/Phi-3-mini-4k-instruct
+2. Phi-4 Mini Model (MIT License)
+   https://huggingface.co/microsoft/Phi-4-mini-instruct
 
 3. gRPC (Apache License 2.0)
    https://github.com/grpc/grpc-dotnet

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SentinAI - Autonomous Windows Storage Agent
 
-**SentinAI** is an autonomous agent for Windows that intelligently manages your storage using a **hybrid AI + RAG + heuristics approach**. It combines fast rule-based analysis with Phi-3 Mini AI and Weaviate vector memory for making safe, context-aware cleanup decisions.
+**SentinAI** is an autonomous agent for Windows that intelligently manages your storage using a **hybrid AI + RAG + heuristics approach**. It combines fast rule-based analysis with Phi-4 Mini AI and Weaviate vector memory for making safe, context-aware cleanup decisions.
 
 ## 🎯 Core Philosophy
 
@@ -18,7 +18,7 @@ The application consists of multiple components:
 |-----------|-----------|----------------|
 | **Web Dashboard** | Blazor Server (.NET 8) | User interface, Brain hosting, API |
 | **Sentinel Service** | .NET 8 Worker Service | Monitors USN Journal, executes cleanup |
-| **Brain (Hybrid AI)** | ONNX Runtime GenAI + Phi-3 Mini | Analyzes folders, makes safety decisions |
+| **Brain (Hybrid AI)** | ONNX Runtime GenAI + Phi-4 Mini | Analyzes folders, makes safety decisions |
 | **RAG Memory** | Weaviate + Ollama (nomic-embed-text) | Vector storage for past decisions |
 | **Shared Library** | .NET 8 Class Library | Models, Protos, shared services |
 
@@ -35,7 +35,7 @@ The application consists of multiple components:
    ├── Query similar past decisions from vector store
    └── Include relevant memories in AI prompt
 
-3. AI DECISION (Phi-3 Mini)
+3. AI DECISION (Phi-4 Mini)
    ├── Receives heuristic context + RAG memories
    ├── Analyzes folder + files with historical context
    └── Makes FINAL safe/unsafe decision
@@ -63,7 +63,7 @@ The application consists of multiple components:
 ┌─────────────────────────────────────────────────────────────────┐
 │                      AgentBrain Service                         │
 │  ┌─────────────┐  ┌─────────────┐  ┌─────────────────────────┐  │
-│  │ Heuristics  │  │   Phi-3     │  │    RAG Memory Store     │  │
+│  │ Heuristics  │  │  Phi-4     │  │    RAG Memory Store     │  │
 │  │   Engine    │──│  ONNX AI    │──│  (Weaviate + Ollama)    │  │
 │  └─────────────┘  └─────────────┘  └─────────────────────────┘  │
 └─────────────────────────────────────────────────────────────────┘
@@ -81,7 +81,7 @@ The application consists of multiple components:
 ## 🚀 Features
 
 ### 🧠 Brain Analysis Engine
-- **Phi-3 Mini 4K Instruct** - Microsoft's compact yet capable LLM (~2.5GB)
+- **Phi-4 Mini Instruct** - Microsoft's powerful compact LLM with enhanced reasoning (~2.5GB)
 - **CPU or DirectML (GPU)** - Configurable execution provider
 - **Hybrid approach** - Heuristics validate, RAG retrieves context, AI decides
 - **Structured output** - JSON responses for reliable parsing
@@ -186,7 +186,7 @@ dotnet build SentinAI.sln
 
 ### 2. Download AI Model
 
-The Phi-3 model (~2.5GB) downloads automatically on first run, or manually:
+The Phi-4 Mini model (~2.5GB) downloads automatically on first run, or manually:
 
 ```powershell
 # Download CPU model (recommended)
@@ -196,7 +196,7 @@ The Phi-3 model (~2.5GB) downloads automatically on first run, or manually:
 .\download-models.ps1 -Provider DirectML
 
 # Or download both
-.\download-models.ps1 -Provider All
+.\download-models.ps1 -Provider Both
 ```
 
 ### 3. Setup RAG Memory (Optional but Recommended)
@@ -235,7 +235,7 @@ Edit `src/SentinAI.Web/appsettings.json`:
     "ModelPath": "",
     "ForceModelRedownload": false,
     "InferenceTimeoutSeconds": 60,
-    "MaxSequenceLength": 2048,
+    "MaxSequenceLength": 4096,
     "MaxOutputTokens": 150,
     "Temperature": 0.1
   },
@@ -259,8 +259,8 @@ Edit `src/SentinAI.Web/appsettings.json`:
 ### Model Locations
 
 Models are stored in:
-- **CPU:** `%LocalAppData%\SentinAI\Models\Phi3-Mini-CPU\`
-- **DirectML:** `%LocalAppData%\SentinAI\Models\Phi3-Mini-DirectML\`
+- **CPU:** `%LocalAppData%\SentinAI\Models\Phi4-Mini-CPU\`
+- **DirectML:** `%LocalAppData%\SentinAI\Models\Phi4-Mini-DirectML\`
 
 ## 🔐 Security
 
@@ -318,7 +318,7 @@ Enable detailed AI logs in `appsettings.json`:
 
 - [x] Hybrid AI + Heuristics engine
 - [x] CPU and DirectML support
-- [x] Phi-3 Mini integration
+- [x] Phi-4 Mini integration
 - [x] Winapp2 rules parser
 - [x] Web dashboard
 - [x] RAG memory system (Weaviate + Ollama)
@@ -337,7 +337,7 @@ MIT License - See [LICENSE](LICENSE) for details.
 
 **Dependencies:**
 - [ONNX Runtime GenAI](https://github.com/microsoft/onnxruntime-genai) - MIT
-- [Phi-3 Mini](https://huggingface.co/microsoft/Phi-3-mini-4k-instruct) - MIT
+- [Phi-4 Mini](https://huggingface.co/microsoft/Phi-4-mini-instruct) - MIT
 - [Winapp2](https://github.com/MoscaDotTo/Winapp2) - CC BY-NC-SA
 - [Weaviate](https://weaviate.io/) - BSD-3-Clause
 - [Ollama](https://ollama.ai/) - MIT
@@ -355,4 +355,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
 
 ---
 
-**Built with** .NET 8, Blazor, ONNX Runtime, Phi-3 AI, Weaviate, and Ollama
+**Built with** .NET 8, Blazor, ONNX Runtime, Phi-4 Mini AI, Weaviate, and Ollama

--- a/download-models.ps1
+++ b/download-models.ps1
@@ -1,10 +1,10 @@
 <#
 .SYNOPSIS
-    Downloads Phi-3 Mini ONNX models for SentinAI Brain
+    Downloads Phi-4 Mini ONNX models for SentinAI Brain
 
 .DESCRIPTION
     This script downloads both CPU and DirectML (GPU) variants of the 
-    Phi-3 Mini 4K Instruct ONNX model from HuggingFace.
+    Phi-4 Mini Instruct ONNX model from HuggingFace.
 
 .PARAMETER Provider
     Which model to download: "CPU", "DirectML", or "Both" (default)
@@ -35,7 +35,7 @@ param(
 $ErrorActionPreference = "Stop"
 
 # Configuration
-$HuggingFaceRepo = "microsoft/Phi-3-mini-4k-instruct-onnx"
+$HuggingFaceRepo = "microsoft/Phi-4-mini-instruct-onnx"
 $BaseUrl = "https://huggingface.co/$HuggingFaceRepo/resolve/main"
 
 $ModelsDir = Join-Path $env:LOCALAPPDATA "SentinAI\Models"
@@ -44,13 +44,13 @@ $ModelsDir = Join-Path $env:LOCALAPPDATA "SentinAI\Models"
 $Models = @{
     "CPU" = @{
         Subdirectory = "cpu_and_mobile/cpu-int4-rtn-block-32-acc-level-4"
-        LocalFolder = "Phi3-Mini-CPU"
-        ModelFile = "phi3-mini-4k-instruct-cpu-int4-rtn-block-32-acc-level-4.onnx"
-        DataFile = "phi3-mini-4k-instruct-cpu-int4-rtn-block-32-acc-level-4.onnx.data"
+        LocalFolder = "Phi4-Mini-CPU"
+        ModelFile = "model.onnx"
+        DataFile = "model.onnx.data"
     }
     "DirectML" = @{
-        Subdirectory = "directml/directml-int4-awq-block-128"
-        LocalFolder = "Phi3-Mini-DirectML"
+        Subdirectory = "gpu/gpu-int4-rtn-block-32"
+        LocalFolder = "Phi4-Mini-DirectML"
         ModelFile = "model.onnx"
         DataFile = "model.onnx.data"
     }
@@ -199,7 +199,7 @@ function Download-Model {
 }
 
 # Main script
-Write-Header "SentinAI Phi-3 Model Downloader"
+Write-Header "SentinAI Phi-4 Mini Model Downloader"
 Write-Host "  Models Directory: $ModelsDir" -ForegroundColor Gray
 Write-Host "  Provider: $Provider" -ForegroundColor Gray
 Write-Host "  Force: $Force" -ForegroundColor Gray

--- a/src/SentinAI.Brain/Services/AgentBrain.cs
+++ b/src/SentinAI.Brain/Services/AgentBrain.cs
@@ -33,7 +33,7 @@ public class ModelInteractionEventArgs : EventArgs
 }
 
 /// <summary>
-/// The "Mind" - Runs Phi-3 Mini model for intelligent file analysis
+/// The "Mind" - Runs Phi-4 Mini model for intelligent file analysis
 /// Uses ONNX Runtime GenAI with DirectML for GPU/NPU acceleration
 /// </summary>
 public class AgentBrain : IAgentBrain, IDisposable

--- a/src/SentinAI.Web/Components/Pages/About.razor
+++ b/src/SentinAI.Web/Components/Pages/About.razor
@@ -24,7 +24,7 @@
                         to agentically solve Windows storage issues once and for always! 🚀
                     </p>
                     <p class="card-text text-muted">
-                        SentinAI is an intelligent, privacy-first cleanup agent that uses local AI (Phi-3) 
+                        SentinAI is an intelligent, privacy-first cleanup agent that uses local AI (Phi-4 Mini) 
                         to understand your files and make smart decisions about what's safe to delete—without 
                         sending a single byte of your data to the cloud.
                     </p>
@@ -43,7 +43,7 @@
                         </li>
                         <li class="mb-2">
                             <span class="text-success me-2">✓</span>
-                            <strong>AI-Powered Analysis</strong> - Phi-3 Mini understands file context and intent
+                            <strong>AI-Powered Analysis</strong> - Phi-4 Mini understands file context and intent
                         </li>
                         <li class="mb-2">
                             <span class="text-success me-2">✓</span>
@@ -74,7 +74,7 @@
                         <div class="col-md-6">
                             <ul class="list-unstyled">
                                 <li class="mb-1"><span class="badge bg-primary me-2">.NET 8</span> Blazor Server</li>
-                                <li class="mb-1"><span class="badge bg-info me-2">AI</span> Phi-3 Mini (ONNX)</li>
+                                <li class="mb-1"><span class="badge bg-info me-2">AI</span> Phi-4 Mini (ONNX)</li>
                                 <li class="mb-1"><span class="badge bg-secondary me-2">RAG</span> Weaviate Vector DB</li>
                             </ul>
                         </div>

--- a/src/SentinAI.Web/Components/Pages/BrainMemory.razor
+++ b/src/SentinAI.Web/Components/Pages/BrainMemory.razor
@@ -96,7 +96,7 @@
                         </div>
                         <h6 class="text-center">3. Context-Aware AI</h6>
                         <p class="text-muted small">
-                            Retrieved memories are injected into the AI prompt, helping Phi-3 make 
+                            Retrieved memories are injected into the AI prompt, helping Phi-4 Mini make 
                             consistent decisions based on what worked before.
                         </p>
                     </div>

--- a/src/SentinAI.Web/Components/Pages/Dashboard.razor
+++ b/src/SentinAI.Web/Components/Pages/Dashboard.razor
@@ -218,7 +218,7 @@
                     {
                         <div class="alert alert-warning mt-3 mb-0">
                             <strong>⚠️ Model downloaded but not loaded!</strong> 
-                            The Phi-3 model files exist but failed to load. Check the console logs for errors.
+                            The Phi-4 Mini model files exist but failed to load. Check the console logs for errors.
                             Try clicking "Force Model Re-download" below to reload.
                         </div>
                     }
@@ -226,7 +226,7 @@
                     {
                         <div class="alert alert-info mt-3 mb-0">
                             <strong>ℹ️ Model not downloaded.</strong> 
-                            Click "Force Model Re-download" below to download the Phi-3 model (~2.5GB).
+                            Click "Force Model Re-download" below to download the Phi-4 Mini model (~2.5GB).
                         </div>
                     }
                 }
@@ -388,7 +388,7 @@
                 <h5 class="mb-0">Model Operations</h5>
             </div>
             <div class="card-body">
-                <p class="text-muted mb-3">Need to pull the latest Phi-3 checkpoint? Trigger a fresh download and Brain re-initialization without touching the command line.</p>
+                <p class="text-muted mb-3">Need to pull the latest Phi-4 Mini checkpoint? Trigger a fresh download and Brain re-initialization without touching the command line.</p>
                 @if (!string.IsNullOrWhiteSpace(modelRefreshMessage))
                 {
                     <div class="alert @modelRefreshAlertClass" role="alert">

--- a/src/SentinAI.Web/Services/AgentBrain.cs
+++ b/src/SentinAI.Web/Services/AgentBrain.cs
@@ -36,12 +36,12 @@ public interface IAgentBrain
 }
 
 /// <summary>
-/// Hybrid AI Brain: Heuristics provide context, Phi-3 model makes final decisions
+/// Hybrid AI Brain: Heuristics provide context, Phi-4 Mini model makes final decisions
 /// 
 /// Flow:
 /// 1. Heuristic analysis runs first (fast, rule-based)
 /// 2. Heuristic results become context for AI model
-/// 3. AI model (Phi-3) makes final SafeToDelete decision
+/// 3. AI model (Phi-4 Mini) makes final SafeToDelete decision
 /// 4. Falls back to heuristics-only if model unavailable
 /// </summary>
 public class AgentBrain : IAgentBrain, IDisposable
@@ -114,7 +114,7 @@ public class AgentBrain : IAgentBrain, IDisposable
             }
 
             // Load the ONNX model
-            _logger.LogInformation("📦 Loading Phi-3 ONNX model ({Provider})...", _config.GetProviderDisplayName());
+            _logger.LogInformation("📦 Loading Phi-4 Mini ONNX model ({Provider})...", _config.GetProviderDisplayName());
             _logger.LogInformation("📂 Model files: {Files}", string.Join(", ", Directory.GetFiles(modelPath).Select(Path.GetFileName)));
 
             await _modelLock.WaitAsync();
@@ -131,7 +131,7 @@ public class AgentBrain : IAgentBrain, IDisposable
                 _logger.LogInformation("✅ Tokenizer created in {Duration}ms", modelLoadSw.ElapsedMilliseconds);
 
                 _isModelLoaded = true;
-                _logger.LogInformation("✅ Phi-3 model loaded successfully! AI decisions enabled. Total load time: {Duration}ms", modelLoadSw.ElapsedMilliseconds);
+                _logger.LogInformation("✅ Phi-4 Mini model loaded successfully! AI decisions enabled. Total load time: {Duration}ms", modelLoadSw.ElapsedMilliseconds);
             }
             catch (Exception modelEx)
             {
@@ -159,7 +159,7 @@ public class AgentBrain : IAgentBrain, IDisposable
         catch (Exception ex)
         {
             sw.Stop();
-            _logger.LogError(ex, "❌ Failed to load Phi-3 model. Falling back to heuristic-only mode.");
+            _logger.LogError(ex, "❌ Failed to load Phi-4 Mini model. Falling back to heuristic-only mode.");
             _isInitialized = true;
             _isModelLoaded = false;
             return await Task.FromResult(true); // Still usable in heuristic mode
@@ -200,7 +200,7 @@ public class AgentBrain : IAgentBrain, IDisposable
 
         if (_isModelLoaded && _model != null && _tokenizer != null)
         {
-            _logger.LogInformation("🤖 [Step 2/2] Phi-3 AI making final decision (heuristics as context)...");
+            _logger.LogInformation("🤖 [Step 2/2] Phi-4 Mini AI making final decision (heuristics as context)...");
 
             try
             {

--- a/src/SentinAI.Web/Services/BrainConfiguration.cs
+++ b/src/SentinAI.Web/Services/BrainConfiguration.cs
@@ -31,9 +31,9 @@ public class BrainConfiguration
 
     /// <summary>
     /// Maximum total sequence length (input tokens + output tokens)
-    /// Phi-3 Mini supports up to 4096 tokens context window
+    /// Phi-4 Mini supports up to 128k tokens context window
     /// </summary>
-    public int MaxSequenceLength { get; set; } = 2048;
+    public int MaxSequenceLength { get; set; } = 4096;
 
     /// <summary>
     /// Maximum tokens to generate in the output response
@@ -63,19 +63,16 @@ public class BrainConfiguration
     public string GetModelSubdirectory()
     {
         return UseDirectML
-            ? "directml/directml-int4-awq-block-128"  // GPU/DirectML version
+            ? "gpu/gpu-int4-rtn-block-32"  // GPU/DirectML version
             : "cpu_and_mobile/cpu-int4-rtn-block-32-acc-level-4";  // CPU version
     }
 
     /// <summary>
-    /// Gets the model ONNX file names (different for CPU vs DirectML)
+    /// Gets the model ONNX file names (same for CPU and DirectML in Phi-4)
     /// </summary>
     public (string OnnxFile, string OnnxDataFile) GetModelFileNames()
     {
-        return UseDirectML
-            ? ("model.onnx", "model.onnx.data")
-            : ("phi3-mini-4k-instruct-cpu-int4-rtn-block-32-acc-level-4.onnx",
-               "phi3-mini-4k-instruct-cpu-int4-rtn-block-32-acc-level-4.onnx.data");
+        return ("model.onnx", "model.onnx.data");
     }
 
     /// <summary>

--- a/src/SentinAI.Web/Services/BrainInitializationService.cs
+++ b/src/SentinAI.Web/Services/BrainInitializationService.cs
@@ -53,7 +53,7 @@ public class BrainInitializationService : BackgroundService
 
             if (!modelExists)
             {
-                _logger.LogInformation("⬇️ Downloading Phi-3 model ({Provider})... (this may take a while)", executionProvider);
+                _logger.LogInformation("⬇️ Downloading Phi-4 Mini model ({Provider})... (this may take a while)", executionProvider);
                 var downloadStart = sw.ElapsedMilliseconds;
 
                 try
@@ -69,7 +69,7 @@ public class BrainInitializationService : BackgroundService
             }
             else
             {
-                _logger.LogInformation("✅ Phi-3 model ({Provider}) already cached at {Path}", executionProvider, modelPath);
+                _logger.LogInformation("✅ Phi-4 Mini model ({Provider}) already cached at {Path}", executionProvider, modelPath);
 
                 // List model files
                 if (Directory.Exists(modelPath))

--- a/src/SentinAI.Web/Services/ModelDownloadService.cs
+++ b/src/SentinAI.Web/Services/ModelDownloadService.cs
@@ -16,12 +16,12 @@ public interface IModelDownloadService
 }
 
 /// <summary>
-/// Handles on-demand downloading of the Phi-3 ONNX model
+/// Handles on-demand downloading of the Phi-4 Mini ONNX model
 /// Downloads from HuggingFace - supports both CPU and DirectML variants
 /// </summary>
 public class ModelDownloadService : IModelDownloadService
 {
-    private const string MODEL_REPO = "microsoft/Phi-3-mini-4k-instruct-onnx";
+    private const string MODEL_REPO = "microsoft/Phi-4-mini-instruct-onnx";
 
     // These are set dynamically based on execution provider
     private readonly string[] _modelFiles;
@@ -62,7 +62,7 @@ public class ModelDownloadService : IModelDownloadService
 
         // Store model in LocalApplicationData with provider-specific subfolder
         var appData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
-        var providerFolder = _config.UseCpu ? "Phi3-Mini-CPU" : "Phi3-Mini-DirectML";
+        var providerFolder = _config.UseCpu ? "Phi4-Mini-CPU" : "Phi4-Mini-DirectML";
 
         _localModelPath = !string.IsNullOrEmpty(_config.ModelPath)
             ? _config.ModelPath
@@ -121,7 +121,7 @@ public class ModelDownloadService : IModelDownloadService
 
         if (cacheReady && !effectiveForce)
         {
-            _logger.LogInformation("✅ Phi-3 model ({Provider}) already cached at {Path}.", _config.GetProviderDisplayName(), targetPath);
+            _logger.LogInformation("✅ Phi-4 Mini model ({Provider}) already cached at {Path}.", _config.GetProviderDisplayName(), targetPath);
             return;
         }
 
@@ -241,7 +241,7 @@ public class ModelDownloadService : IModelDownloadService
         try
         {
             Directory.Delete(targetPath, true);
-            _logger.LogInformation("Deleted legacy Phi-3 cache at {Path}.", targetPath);
+            _logger.LogInformation("Deleted legacy model cache at {Path}.", targetPath);
         }
         catch (Exception ex)
         {

--- a/src/SentinAI.Web/appsettings.json
+++ b/src/SentinAI.Web/appsettings.json
@@ -13,7 +13,7 @@
     "ModelPath": "",
     "ForceModelRedownload": false,
     "InferenceTimeoutSeconds": 60,
-    "MaxSequenceLength": 2048,
+    "MaxSequenceLength": 4096,
     "MaxOutputTokens": 150,
     "Temperature": 0.1
   },

--- a/tests/SentinAI.Web.Tests/Services/BrainConfigurationTests.cs
+++ b/tests/SentinAI.Web.Tests/Services/BrainConfigurationTests.cs
@@ -15,7 +15,7 @@ public class BrainConfigurationTests
         Assert.Equal(string.Empty, config.ModelPath);
         Assert.False(config.ForceModelRedownload);
         Assert.Equal(30, config.InferenceTimeoutSeconds);
-        Assert.Equal(2048, config.MaxSequenceLength);
+        Assert.Equal(4096, config.MaxSequenceLength);
         Assert.Equal(150, config.MaxOutputTokens);
         Assert.Equal(0.1, config.Temperature);
     }
@@ -95,7 +95,7 @@ public class BrainConfigurationTests
         var subdir = config.GetModelSubdirectory();
 
         // Assert
-        Assert.Equal("directml/directml-int4-awq-block-128", subdir);
+        Assert.Equal("gpu/gpu-int4-rtn-block-32", subdir);
     }
 
     [Fact]
@@ -108,8 +108,8 @@ public class BrainConfigurationTests
         var (onnxFile, onnxDataFile) = config.GetModelFileNames();
 
         // Assert
-        Assert.Equal("phi3-mini-4k-instruct-cpu-int4-rtn-block-32-acc-level-4.onnx", onnxFile);
-        Assert.Equal("phi3-mini-4k-instruct-cpu-int4-rtn-block-32-acc-level-4.onnx.data", onnxDataFile);
+        Assert.Equal("model.onnx", onnxFile);
+        Assert.Equal("model.onnx.data", onnxDataFile);
     }
 
     [Fact]


### PR DESCRIPTION
- Replace Phi-3 Mini with Phi-4 Mini throughout codebase
- Update HuggingFace repo: microsoft/Phi-4-mini-instruct-onnx
- Update model paths: cpu_and_mobile/cpu-int4-rtn-block-32-acc-level-4 (CPU)
- Update model paths: gpu/gpu-int4-rtn-block-32 (DirectML)
- Increase MaxSequenceLength to 4096 tokens (Phi-4 supports 128k)
- Update all documentation (README, ARCHITECTURE, About page)
- Update download-models.ps1 with correct Phi-4 paths
- Update tests for new configuration values

Phi-4 Mini provides improved reasoning and instruction following over Phi-3 while maintaining similar size (~4.7GB ONNX quantized)

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
